### PR TITLE
Fix: TopDownPlayer Interaction Func

### DIFF
--- a/.idea/.idea.GameOver/.idea/workspace.xml
+++ b/.idea/.idea.GameOver/.idea/workspace.xml
@@ -5,7 +5,6 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="b92e3963-3ac6-4419-ae77-cd6c1cffc83d" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Runtime/CH1/Main/PlayerFunction/TopDownInteraction.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Runtime/CH1/Main/PlayerFunction/TopDownInteraction.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Assets/Scripts/Tests/Runtime/TopDownPlayerTests.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Tests/Runtime/TopDownPlayerTests.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -35,29 +34,29 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Discover.Launch.Via.Unity&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;125-feat-msc01-dialogue-system&quot;,
-    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.pluginManager&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Discover.Launch.Via.Unity": "true",
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "git-widget-placeholder": "165-bug-testcode-testplayerinteractionfail",
+    "ignore.virus.scanning.warn.message": "true",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "settings.editor.selected.configurable": "preferences.pluginManager",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;rider.external.source.directories&quot;: [
-      &quot;C:\\Users\\USER\\AppData\\Roaming\\JetBrains\\Rider2023.2\\resharper-host\\DecompilerCache&quot;,
-      &quot;C:\\Users\\USER\\AppData\\Roaming\\JetBrains\\Rider2023.2\\resharper-host\\SourcesCache&quot;,
-      &quot;C:\\Users\\USER\\AppData\\Local\\Symbols\\src&quot;
+  "keyToStringList": {
+    "rider.external.source.directories": [
+      "C:\\Users\\USER\\AppData\\Roaming\\JetBrains\\Rider2023.2\\resharper-host\\DecompilerCache",
+      "C:\\Users\\USER\\AppData\\Roaming\\JetBrains\\Rider2023.2\\resharper-host\\SourcesCache",
+      "C:\\Users\\USER\\AppData\\Local\\Symbols\\src"
     ]
   }
-}</component>
+}]]></component>
   <component name="RunManager" selected="Unity 에디터에 연결.Unity 에디터에 연결">
     <configuration name="유닛 테스트(배치 모드)" type="RunUnityExe" factoryName="Unity Executable">
       <option name="EXE_PATH" value="C:\Program Files\Unity\Hub\Editor\2022.3.10f1\Editor\Unity.exe" />

--- a/Assets/Plugins/Febucci.meta
+++ b/Assets/Plugins/Febucci.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f2e361ae3ab067478a09a170923112c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Febucci/Text Animator.meta
+++ b/Assets/Plugins/Febucci/Text Animator.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3c851caa99d03d4a8c8842ded166a7c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Febucci/Text Animator/Extra.meta
+++ b/Assets/Plugins/Febucci/Text Animator/Extra.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9589a74fa45a59448bb1a6a9aa8a597f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Febucci/Text Animator/Extra/Typewriter Sound - Package.unitypackage.meta
+++ b/Assets/Plugins/Febucci/Text Animator/Extra/Typewriter Sound - Package.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 560a88da2bbc70140bed167f0ba7fe37
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Febucci/Text Animator/Integrations.meta
+++ b/Assets/Plugins/Febucci/Text Animator/Integrations.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b68fd61c2b78d79478cbaac617d6bc42
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Febucci/Text Animator/Integrations/PlayMaker - Integration.unitypackage.meta
+++ b/Assets/Plugins/Febucci/Text Animator/Integrations/PlayMaker - Integration.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fb01be13d6e88ca488dda82150319bfc
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Febucci/Text Animator/Integrations/Visual Scripting - Integration.unitypackage.meta
+++ b/Assets/Plugins/Febucci/Text Animator/Integrations/Visual Scripting - Integration.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 117dcc671050f5247bd8743b91ecaab7
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/Runtime/TopDownPlayerTests.cs
+++ b/Assets/Scripts/Tests/Runtime/TopDownPlayerTests.cs
@@ -32,11 +32,11 @@ namespace Tests.Runtime
             _player = _playerObject.AddComponent<TopDownPlayer>();
             _player.transform.position = Vector3.zero;
             
-            yield return null;
-            
             _movement = new TopDownMovement(5.0f, _player.transform);
             _animation = new TopDownAnimation(_player.GetComponent<Animator>(), 0.5f);
             _interaction = new TopDownInteraction(_player.transform, LayerMask.GetMask("Object"), 1f);
+            
+            yield return new WaitForFixedUpdate();
         }
         
         [UnityTest]
@@ -46,7 +46,7 @@ namespace Tests.Runtime
             
             _movement.Move(movementInput);
             
-            yield return null;
+            yield return new WaitForFixedUpdate();
             
             Assert.AreNotEqual(Vector3.zero, _player.transform.position);
         }
@@ -59,7 +59,7 @@ namespace Tests.Runtime
             
             bool isMoving = animator.GetBool("IsMoving");
             
-            yield return null;
+            yield return new WaitForFixedUpdate();
             
             Assert.IsTrue(isMoving);
         }
@@ -74,36 +74,40 @@ namespace Tests.Runtime
             
             interactionObject.transform.position = new Vector3(1.0f, 0.0f, 0.0f);
             
-            yield return null;
+            yield return new WaitForFixedUpdate();
             
             Assert.IsTrue(_interaction.Interact(Vector2.right));
             
-            GameObject.DestroyImmediate(interactionObject);
+            Object.DestroyImmediate(interactionObject);
         }
         
-        // [UnityTest]
-        // public IEnumerator TestPlayerInteractionFail()
-        // {
-        //     GameObject interactionObject = new GameObject("InteractionTestObject2");
-        //     interactionObject.AddComponent<CircleCollider2D>();
-        //     interactionObject.AddComponent<NpcInteraction>();
-        //     interactionObject.layer = LayerMask.NameToLayer("Object");
-        //     
-        //     interactionObject.transform.position = new Vector3(1.0f, 0.0f, 0.0f);
-        //     
-        //     yield return null;
-        //     
-        //     Assert.IsFalse(_interaction.Interact(Vector2.left));
-        //     
-        //     GameObject.DestroyImmediate(interactionObject);
-        // }
+        [UnityTest]
+        public IEnumerator TestPlayerInteractionFail()
+        {
+            GameObject interactionObject = new GameObject("InteractionTestObject2");
+            interactionObject.AddComponent<CircleCollider2D>();
+            interactionObject.AddComponent<NpcInteraction>();
+            interactionObject.layer = LayerMask.NameToLayer("Object");
+            
+            interactionObject.transform.position = new Vector3(1.0f, 0.0f, 0.0f);
+            
+            yield return new WaitForFixedUpdate();
+            
+            Assert.IsFalse(_interaction.Interact(Vector2.left));
+            
+            Object.DestroyImmediate(interactionObject);
+        }
         
         [UnityTearDown]
         public IEnumerator TearDown()
         {
-            GameObject.Destroy(_playerObject);
+            Object.Destroy(_playerObject);
+
+            _interaction = null;
+            _movement = null;
+            _animation = null;
             
-            yield return null;
+            yield return new WaitForFixedUpdate();
         }
     }
 }


### PR DESCRIPTION
드디어 고쳤습니다..

Edit Mode에서 테스트되던게 왜 문제인지 생각을 못한 것 같네요

코루틴으로 처리될 때 오브젝트 생성 삭제 등의 작업 이후에 1프레임을 넘어가줘야 하는데 전에는 `yield return null`로 넘기는게 가능한줄 알았는데 그건 Edit모드에서 사용하는 방법이고 PlayMode 즉, 직접 씬에 배치하여 테스트 하는 경우엔 `yield return new WaitForFixedUpdate();`으로 1프레임을 넘겨야 동작합니다.

자세한 내용은 좀 더 조사해보고 정리되는 대로 알려드릴께요.